### PR TITLE
fix: vote deadlock, stale cache, and tie notification (T56)

### DIFF
--- a/Bressolium/backend/BressoliumProject/app/DTOs/SyncResponseDTO.php
+++ b/Bressolium/backend/BressoliumProject/app/DTOs/SyncResponseDTO.php
@@ -10,5 +10,6 @@ final readonly class SyncResponseDTO
         public array $inventory,
         public array $technologies,
         public array $inventions,
+        public bool $hasVoted = false,
     ) {}
 }

--- a/Bressolium/backend/BressoliumProject/app/DTOs/SyncResponseDTO.php
+++ b/Bressolium/backend/BressoliumProject/app/DTOs/SyncResponseDTO.php
@@ -11,5 +11,6 @@ final readonly class SyncResponseDTO
         public array $technologies,
         public array $inventions,
         public bool $hasVoted = false,
+        public array $lastRoundResult = [],
     ) {}
 }

--- a/Bressolium/backend/BressoliumProject/app/Http/Resources/SyncResource.php
+++ b/Bressolium/backend/BressoliumProject/app/Http/Resources/SyncResource.php
@@ -13,11 +13,12 @@ class SyncResource extends JsonResource
     {
         return [
             'current_round' => $this->dto->currentRound,
-            'user_actions' => $this->dto->userActions,
-            'inventory' => $this->dto->inventory,
-            'progress' => [
+            'user_actions'  => $this->dto->userActions,
+            'has_voted'     => $this->dto->hasVoted,
+            'inventory'     => $this->dto->inventory,
+            'progress'      => [
                 'technologies' => $this->dto->technologies,
-                'inventions' => $this->dto->inventions,
+                'inventions'   => $this->dto->inventions,
             ],
         ];
     }

--- a/Bressolium/backend/BressoliumProject/app/Http/Resources/SyncResource.php
+++ b/Bressolium/backend/BressoliumProject/app/Http/Resources/SyncResource.php
@@ -14,7 +14,8 @@ class SyncResource extends JsonResource
         return [
             'current_round' => $this->dto->currentRound,
             'user_actions'  => $this->dto->userActions,
-            'has_voted'     => $this->dto->hasVoted,
+            'has_voted'          => $this->dto->hasVoted,
+            'last_round_result'  => $this->dto->lastRoundResult ?: null,
             'inventory'     => $this->dto->inventory,
             'progress'      => [
                 'technologies' => $this->dto->technologies,

--- a/Bressolium/backend/BressoliumProject/app/Models/Round.php
+++ b/Bressolium/backend/BressoliumProject/app/Models/Round.php
@@ -20,6 +20,8 @@ class Round extends Model
         'number',
         'start_date',
         'ended_at',
+        'no_consensus',
+        'last_built_invention_id',
     ];
 
     /**

--- a/Bressolium/backend/BressoliumProject/app/Repositories/Contracts/CloseRoundRepositoryInterface.php
+++ b/Bressolium/backend/BressoliumProject/app/Repositories/Contracts/CloseRoundRepositoryInterface.php
@@ -37,4 +37,8 @@ interface CloseRoundRepositoryInterface
     public function markAfkPlayers(Round $round, Game $game): void;
 
     public function allNonAfkPlayersHaveVoted(Round $round, Game $game): bool;
+
+    public function hasInventionVoteTie(Round $round): bool;
+
+    public function markRoundResult(Round $round, string $inventionId, bool $noConsensus): void;
 }

--- a/Bressolium/backend/BressoliumProject/app/Repositories/Contracts/SyncRepositoryInterface.php
+++ b/Bressolium/backend/BressoliumProject/app/Repositories/Contracts/SyncRepositoryInterface.php
@@ -16,4 +16,6 @@ interface SyncRepositoryInterface
     public function getTechnologies(Game $game): array;
 
     public function getInventions(Game $game): array;
+
+    public function hasVotedThisRound(Round $round, string $userId): bool;
 }

--- a/Bressolium/backend/BressoliumProject/app/Repositories/Contracts/SyncRepositoryInterface.php
+++ b/Bressolium/backend/BressoliumProject/app/Repositories/Contracts/SyncRepositoryInterface.php
@@ -18,4 +18,6 @@ interface SyncRepositoryInterface
     public function getInventions(Game $game): array;
 
     public function hasVotedThisRound(Round $round, string $userId): bool;
+
+    public function getLastRoundResult(Round $currentRound): array;
 }

--- a/Bressolium/backend/BressoliumProject/app/Repositories/Eloquent/CloseRoundRepository.php
+++ b/Bressolium/backend/BressoliumProject/app/Repositories/Eloquent/CloseRoundRepository.php
@@ -62,7 +62,7 @@ class CloseRoundRepository implements CloseRoundRepositoryInterface
 
     public function inventionPrerequisitesMet(Game $game, Invention $invention): bool
     {
-        $activeTechIds = $game->technologies()->wherePivot('is_active', true)->pluck('id');
+        $activeTechIds = $game->technologies()->wherePivot('is_active', true)->get()->pluck('id');
 
         foreach ($invention->inventionPrerequisites as $prerequisite) {
             if ($prerequisite->prereq_type === 'invention') {

--- a/Bressolium/backend/BressoliumProject/app/Repositories/Eloquent/CloseRoundRepository.php
+++ b/Bressolium/backend/BressoliumProject/app/Repositories/Eloquent/CloseRoundRepository.php
@@ -200,6 +200,33 @@ class CloseRoundRepository implements CloseRoundRepositoryInterface
         }
     }
 
+    public function hasInventionVoteTie(Round $round): bool
+    {
+        $results = DB::table('votes')
+            ->where('round_id', $round->id)
+            ->whereNotNull('invention_id')
+            ->select('invention_id', DB::raw('count(*) as vote_count'))
+            ->groupBy('invention_id')
+            ->orderByDesc('vote_count')
+            ->get();
+
+        if ($results->count() < 2) {
+            return false;
+        }
+
+        return $results[0]->vote_count === $results[1]->vote_count;
+    }
+
+    public function markRoundResult(Round $round, string $inventionId, bool $noConsensus): void
+    {
+        DB::table('rounds')
+            ->where('id', $round->id)
+            ->update([
+                'no_consensus'             => $noConsensus,
+                'last_built_invention_id'  => $inventionId,
+            ]);
+    }
+
     public function allNonAfkPlayersHaveVoted(Round $round, Game $game): bool
     {
         $activePlayerCount = $game->users()->wherePivot('is_afk', false)->count();

--- a/Bressolium/backend/BressoliumProject/app/Repositories/Eloquent/SyncRepository.php
+++ b/Bressolium/backend/BressoliumProject/app/Repositories/Eloquent/SyncRepository.php
@@ -146,4 +146,25 @@ class SyncRepository implements SyncRepositoryInterface
             ->where('user_id', $userId)
             ->exists();
     }
+
+    public function getLastRoundResult(Round $currentRound): array
+    {
+        $prev = DB::table('rounds')
+            ->where('game_id', $currentRound->game_id)
+            ->where('number', $currentRound->number - 1)
+            ->first();
+
+        if (! $prev || ! $prev->no_consensus || ! $prev->last_built_invention_id) {
+            return [];
+        }
+
+        $name = DB::table('inventions')
+            ->where('id', $prev->last_built_invention_id)
+            ->value('name');
+
+        return [
+            'no_consensus' => true,
+            'built_name'   => $name ?? 'Invento desconocido',
+        ];
+    }
 }

--- a/Bressolium/backend/BressoliumProject/app/Repositories/Eloquent/SyncRepository.php
+++ b/Bressolium/backend/BressoliumProject/app/Repositories/Eloquent/SyncRepository.php
@@ -7,6 +7,7 @@ use App\Models\Invention;
 use App\Models\Round;
 use App\Models\Technology;
 use App\Repositories\Contracts\SyncRepositoryInterface;
+use Illuminate\Support\Facades\DB;
 
 class SyncRepository implements SyncRepositoryInterface
 {
@@ -136,5 +137,13 @@ class SyncRepository implements SyncRepositoryInterface
                 'missing' => $missing,
             ];
         })->values()->toArray();
+    }
+
+    public function hasVotedThisRound(Round $round, string $userId): bool
+    {
+        return DB::table('votes')
+            ->where('round_id', $round->id)
+            ->where('user_id', $userId)
+            ->exists();
     }
 }

--- a/Bressolium/backend/BressoliumProject/app/Repositories/Eloquent/SyncRepository.php
+++ b/Bressolium/backend/BressoliumProject/app/Repositories/Eloquent/SyncRepository.php
@@ -80,7 +80,7 @@ class SyncRepository implements SyncRepositoryInterface
         $allInvs = Invention::with(['inventionCosts.resource', 'inventionPrerequisites'])->get();
         $gameInvMap = $game->inventions()->get()->keyBy('id');
         $matMap = $game->materials()->get()->keyBy('id');
-        $activeTechIds = $game->technologies()->wherePivot('is_active', true)->pluck('id');
+        $activeTechIds = $game->technologies()->wherePivot('is_active', true)->get()->pluck('id');
 
         return $allInvs->map(function ($inv) use ($gameInvMap, $allInvs, $matMap, $activeTechIds) {
             $quantity = $gameInvMap->has($inv->id) ? (int) $gameInvMap[$inv->id]->pivot->quantity : 0;

--- a/Bressolium/backend/BressoliumProject/app/Services/CloseRoundService.php
+++ b/Bressolium/backend/BressoliumProject/app/Services/CloseRoundService.php
@@ -68,7 +68,10 @@ class CloseRoundService
             return false;
         }
 
+        $isTie = $this->repository->hasInventionVoteTie($round);
+
         $this->repository->buildInvention($game, $invention);
+        $this->repository->markRoundResult($round, $inventionId, $isTie);
         InventionBuilt::dispatch($game, $invention);
 
         if ($invention->is_final) {

--- a/Bressolium/backend/BressoliumProject/app/Services/SyncService.php
+++ b/Bressolium/backend/BressoliumProject/app/Services/SyncService.php
@@ -29,6 +29,9 @@ class SyncService
             inventory: $this->syncRepository->getInventory($game),
             technologies: $this->syncRepository->getTechnologies($game),
             inventions: $this->syncRepository->getInventions($game),
+            hasVoted: $round
+                ? $this->syncRepository->hasVotedThisRound($round, $userId)
+                : false,
         );
     }
 }

--- a/Bressolium/backend/BressoliumProject/app/Services/SyncService.php
+++ b/Bressolium/backend/BressoliumProject/app/Services/SyncService.php
@@ -32,6 +32,9 @@ class SyncService
             hasVoted: $round
                 ? $this->syncRepository->hasVotedThisRound($round, $userId)
                 : false,
+            lastRoundResult: $round
+                ? $this->syncRepository->getLastRoundResult($round)
+                : [],
         );
     }
 }

--- a/Bressolium/backend/BressoliumProject/database/migrations/2026_05_10_120000_add_no_consensus_to_rounds_table.php
+++ b/Bressolium/backend/BressoliumProject/database/migrations/2026_05_10_120000_add_no_consensus_to_rounds_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('rounds', function (Blueprint $table) {
+            $table->boolean('no_consensus')->nullable()->after('ended_at');
+            $table->foreignUuid('last_built_invention_id')->nullable()->after('no_consensus')
+                ->constrained('inventions')->nullOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('rounds', function (Blueprint $table) {
+            $table->dropForeign(['last_built_invention_id']);
+            $table->dropColumn(['no_consensus', 'last_built_invention_id']);
+        });
+    }
+};

--- a/Bressolium/frontend/bressolium-front/src/features/game/VotingPanel.jsx
+++ b/Bressolium/frontend/bressolium-front/src/features/game/VotingPanel.jsx
@@ -57,7 +57,7 @@ function VoteItem({ name, canVote, missing, quantity, onClick }) {
 }
 
 function VotingPanel({ gameId }) {
-    const { technologies, inventions, userActions, currentRound, isLoading, hasVoted, votedName, vote, abstain } = useVoting(gameId);
+    const { technologies, inventions, userActions, currentRound, lastRoundResult, isLoading, hasVoted, votedName, vote, abstain } = useVoting(gameId);
 
     return (
         <div style={{ display: 'flex', flexDirection: 'column', gap: '4px', padding: '8px', overflowY: 'auto' }}>
@@ -79,6 +79,23 @@ function VotingPanel({ gameId }) {
                 <span>Acciones: {userActions}</span>
                 {currentRound && <span>Jornada {currentRound.number}</span>}
             </div>
+
+            {/* Resultado de la jornada anterior: empate resuelto al azar */}
+            {lastRoundResult?.no_consensus && (
+                <div style={{
+                    padding:         '6px 8px',
+                    backgroundColor: '#fff3e0',
+                    border:          '1px solid #e6961a',
+                    borderLeft:      '3px solid #e6961a',
+                    fontSize:        '10px',
+                    fontWeight:      'bold',
+                    color:           '#b85e00',
+                    textTransform:   'uppercase',
+                    letterSpacing:   '0.05em',
+                }}>
+                    Sin consenso — se construyó {lastRoundResult.built_name} al azar
+                </div>
+            )}
 
             {/* Confirmación de voto */}
             {hasVoted && (

--- a/Bressolium/frontend/bressolium-front/src/features/game/useVoting.js
+++ b/Bressolium/frontend/bressolium-front/src/features/game/useVoting.js
@@ -14,9 +14,10 @@ export function useVoting(gameId) {
     const [votedRound, setVotedRound] = useState(null);
     const [votedName, setVotedName]   = useState(null);
 
-    const rawTechs     = data?.progress?.technologies ?? [];
-    const rawInvs      = data?.progress?.inventions   ?? [];
-    const currentRound = data?.current_round ?? null;
+    const rawTechs       = data?.progress?.technologies ?? [];
+    const rawInvs        = data?.progress?.inventions   ?? [];
+    const currentRound   = data?.current_round ?? null;
+    const lastRoundResult = data?.last_round_result ?? null;
 
     // Server is authoritative; local state gives immediate feedback before the next poll
     const hasVoted = (data?.has_voted ?? false) || votedRound === currentRound?.number;
@@ -64,5 +65,5 @@ export function useVoting(gameId) {
         return closeRoundMutation(gameId);
     }
 
-    return { technologies, inventions, userActions, currentRound, isLoading, isClosing, hasVoted, votedName, vote, abstain, closeRound };
+    return { technologies, inventions, userActions, currentRound, lastRoundResult, isLoading, isClosing, hasVoted, votedName, vote, abstain, closeRound };
 }

--- a/Bressolium/frontend/bressolium-front/src/features/game/useVoting.js
+++ b/Bressolium/frontend/bressolium-front/src/features/game/useVoting.js
@@ -3,8 +3,9 @@ import { bressoliumApi } from '../../services/bressoliumApi';
 
 export function useVoting(gameId) {
     const { data, isLoading } = bressoliumApi.useGetSyncQuery(gameId, {
-        skip:            !gameId,
-        pollingInterval: 30000,
+        skip:                    !gameId,
+        pollingInterval:         30000,
+        refetchOnMountOrArgChange: true,
     });
     const [voteMutation]                                 = bressoliumApi.useVoteMutation();
     const [closeRoundMutation, { isLoading: isClosing }] = bressoliumApi.useCloseRoundMutation();

--- a/Bressolium/frontend/bressolium-front/src/features/game/useVoting.js
+++ b/Bressolium/frontend/bressolium-front/src/features/game/useVoting.js
@@ -6,6 +6,7 @@ export function useVoting(gameId) {
         skip:                    !gameId,
         pollingInterval:         30000,
         refetchOnMountOrArgChange: true,
+        refetchOnFocus:          true,
     });
     const [voteMutation]                                 = bressoliumApi.useVoteMutation();
     const [closeRoundMutation, { isLoading: isClosing }] = bressoliumApi.useCloseRoundMutation();
@@ -17,7 +18,8 @@ export function useVoting(gameId) {
     const rawInvs      = data?.progress?.inventions   ?? [];
     const currentRound = data?.current_round ?? null;
 
-    const hasVoted = votedRound === currentRound?.number;
+    // Server is authoritative; local state gives immediate feedback before the next poll
+    const hasVoted = (data?.has_voted ?? false) || votedRound === currentRound?.number;
 
     // Solo tecnologías pendientes de investigar
     const technologies = rawTechs

--- a/Bressolium/frontend/bressolium-front/src/features/inventory/useInventory.js
+++ b/Bressolium/frontend/bressolium-front/src/features/inventory/useInventory.js
@@ -1,7 +1,11 @@
 import { bressoliumApi } from '../../services/bressoliumApi';
 
 export function useInventory(gameId) {
-    const { data, isLoading, error } = bressoliumApi.useGetSyncQuery(gameId, { skip: !gameId });
+    const { data, isLoading, error } = bressoliumApi.useGetSyncQuery(gameId, {
+        skip:                    !gameId,
+        pollingInterval:         30000,
+        refetchOnMountOrArgChange: true,
+    });
     const materials  = data?.inventory               ?? [];
     const inventions = data?.progress?.inventions    ?? [];
     return { materials, inventions, isLoading, error };

--- a/Bressolium/frontend/bressolium-front/src/features/inventory/useInventory.js
+++ b/Bressolium/frontend/bressolium-front/src/features/inventory/useInventory.js
@@ -5,6 +5,7 @@ export function useInventory(gameId) {
         skip:                    !gameId,
         pollingInterval:         30000,
         refetchOnMountOrArgChange: true,
+        refetchOnFocus:          true,
     });
     const materials  = data?.inventory               ?? [];
     const inventions = data?.progress?.inventions    ?? [];

--- a/Bressolium/frontend/bressolium-front/src/features/techtree/useTechTree.js
+++ b/Bressolium/frontend/bressolium-front/src/features/techtree/useTechTree.js
@@ -15,7 +15,10 @@ import { bressoliumApi } from '../../services/bressoliumApi';
  * @returns {{ completed: TechItem[], available: TechItem[], blocked: TechItem[], isLoading: boolean }}
  */
 export function useTechTree(gameId) {
-    const { data, isLoading } = bressoliumApi.useGetSyncQuery(gameId, { skip: !gameId });
+    const { data, isLoading } = bressoliumApi.useGetSyncQuery(gameId, {
+        skip:                    !gameId,
+        refetchOnMountOrArgChange: true,
+    });
 
     const technologies = data?.progress?.technologies ?? [];
 


### PR DESCRIPTION
## Summary

- **Fix recurring vote deadlock**: added `has_voted` to sync response so vote status survives page reloads; added `refetchOnFocus: true` so backgrounded tabs refresh immediately when focused
- **Fix RTK Query stale error cache**: `refetchOnMountOrArgChange: true` forces a fresh request on every mount instead of serving the cached error state
- **Fix SQL pluck ambiguity**: `->pluck('id')` on a pivot JOIN generated an ambiguous `SELECT id` — changed to `->get()->pluck('id')` in SyncRepository and CloseRoundRepository
- **Tie notification**: when two players vote different inventions, the winner is picked randomly by SQL; the round now records `no_consensus=true` + `last_built_invention_id`; the next sync response includes `last_round_result` and VotingPanel shows a banner: "SIN CONSENSO — SE CONSTRUYÓ [Nombre] AL AZAR"

## Test plan

- [ ] Both players vote the same invention → no banner shown next round
- [ ] Both players vote different inventions → banner "SIN CONSENSO — SE CONSTRUYÓ X AL AZAR" appears at the start of the next round
- [ ] Page reload after voting → "VOTO REGISTRADO" banner still shows (server-side `has_voted`)
- [ ] Backgrounded tab comes back to foreground → sync refreshes immediately
- [ ] Run `php artisan migrate` to apply the new `no_consensus` / `last_built_invention_id` columns

🤖 Generated with [Claude Code](https://claude.com/claude-code)