### PR TITLE
problem with refresh solved

### DIFF
--- a/Bressolium/backend/BressoliumProject/app/Http/Controllers/Api/BoardController.php
+++ b/Bressolium/backend/BressoliumProject/app/Http/Controllers/Api/BoardController.php
@@ -3,7 +3,6 @@
 namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
-use App\Http\Resources\TileResource;
 use App\Models\Game;
 use App\Services\BoardService;
 use App\Support\ResponseBuilder;
@@ -59,7 +58,7 @@ class BoardController extends Controller
         try {
             $tiles = $this->boardService->getBoardForUser($gameId, $request->user()->id);
 
-            return $this->rb->success(TileResource::collection($tiles)->toArray($request));
+            return $this->rb->success($tiles);
         } catch (Exception $e) {
             $status = $e->getCode() === 403 ? 403 : 500;
 

--- a/Bressolium/backend/BressoliumProject/app/Repositories/Eloquent/SyncRepository.php
+++ b/Bressolium/backend/BressoliumProject/app/Repositories/Eloquent/SyncRepository.php
@@ -57,9 +57,10 @@ class SyncRepository implements SyncRepositoryInterface
         }
 
         // Inventos desbloqueados por cada tech (via technology_id)
-        $inventionsUnlockedBy = Invention::all()
-            ->groupBy('technology_id')
-            ->map(fn ($invs) => $invs->pluck('name')->all());
+        $inventionsUnlockedBy = [];
+        foreach (Invention::whereNotNull('technology_id')->get(['name', 'technology_id']) as $inv) {
+            $inventionsUnlockedBy[$inv->technology_id][] = $inv->name;
+        }
 
         return $allTechs->map(function ($tech) use ($gameTechMap, $allTechs, $techsUnlockedBy, $inventionsUnlockedBy) {
             $isActive = isset($gameTechMap[$tech->id])

--- a/Bressolium/backend/BressoliumProject/app/Services/BoardService.php
+++ b/Bressolium/backend/BressoliumProject/app/Services/BoardService.php
@@ -12,7 +12,7 @@ class BoardService
         private CacheService $cacheService,
     ) {}
 
-    public function getBoardForUser(string $gameId, string $userId)
+    public function getBoardForUser(string $gameId, string $userId): array
     {
         if (! $this->boardRepository->isUserInGame($gameId, $userId)) {
             throw new Exception('Forbidden', 403);
@@ -20,7 +20,21 @@ class BoardService
 
         return $this->cacheService->rememberBoard(
             $gameId,
-            fn () => $this->boardRepository->getTilesByGameId($gameId),
+            fn () => $this->boardRepository->getTilesByGameId($gameId)
+                ->map(fn ($tile) => [
+                    'id'           => $tile->id,
+                    'coord_x'      => $tile->coord_x,
+                    'coord_y'      => $tile->coord_y,
+                    'tile_type_id' => $tile->tile_type_id,
+                    'explored'     => (bool) $tile->explored,
+                    'type'         => $tile->type ? [
+                        'id'        => $tile->type->id,
+                        'name'      => $tile->type->name,
+                        'base_type' => $tile->type->base_type,
+                        'level'     => $tile->type->level,
+                    ] : null,
+                ])
+                ->toArray(),
         );
     }
 }

--- a/Bressolium/frontend/bressolium-front/src/features/auth/authSlice.js
+++ b/Bressolium/frontend/bressolium-front/src/features/auth/authSlice.js
@@ -39,7 +39,7 @@ export const loginThunk = createAsyncThunk(
 /** @type {AuthState} */
 const initialState = {
   status: authService.getToken() ? 'LOGGED_IN' : 'IDLE',
-  user: null,
+  user: authService.getUser(),
   error: null,
 };
 

--- a/Bressolium/frontend/bressolium-front/src/features/game/gameSlice.js
+++ b/Bressolium/frontend/bressolium-front/src/features/game/gameSlice.js
@@ -81,10 +81,19 @@ export const joinRandomThunk = createAsyncThunk(
   }
 );
 
+function loadCurrentGame() {
+  try {
+    const raw = localStorage.getItem('current_game');
+    return raw ? JSON.parse(raw) : null;
+  } catch {
+    return null;
+  }
+}
+
 const initialState = {
   availableGames: [],
   myGames: [],
-  currentGame: null,
+  currentGame: loadCurrentGame(),
   status: 'IDLE', // 'IDLE' | 'LOADING' | 'SUCCESS' | 'ERROR'
   error: null,
 };
@@ -98,6 +107,11 @@ const gameSlice = createSlice({
     },
     setCurrentGame: (state, action) => {
       state.currentGame = action.payload;
+      if (action.payload) {
+        localStorage.setItem('current_game', JSON.stringify(action.payload));
+      } else {
+        localStorage.removeItem('current_game');
+      }
     },
   },
   extraReducers: (builder) => {

--- a/Bressolium/frontend/bressolium-front/src/lib/httpClient.js
+++ b/Bressolium/frontend/bressolium-front/src/lib/httpClient.js
@@ -1,5 +1,8 @@
 import axios from 'axios';
 
+let _store = null;
+export const injectStore = (store) => { _store = store; };
+
 const httpClient = axios.create({
     baseURL: import.meta.env.VITE_API_URL ?? 'http://localhost/api/v1',
 });
@@ -20,6 +23,7 @@ httpClient.interceptors.response.use(
     (error) => {
         if (error.response?.status === 401) {
             localStorage.removeItem('auth_token');
+            _store?.dispatch({ type: 'auth/logout' });
         }
         return Promise.reject(error);
     }

--- a/Bressolium/frontend/bressolium-front/src/main.jsx
+++ b/Bressolium/frontend/bressolium-front/src/main.jsx
@@ -3,8 +3,11 @@ import { createRoot } from 'react-dom/client'
 import { BrowserRouter } from 'react-router-dom'
 import { Provider } from 'react-redux'
 import { store } from './store'
+import { injectStore } from './lib/httpClient'
 import './index.css'
 import App from './App.jsx'
+
+injectStore(store);
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>

--- a/Bressolium/frontend/bressolium-front/src/routes/AppRoutes.jsx
+++ b/Bressolium/frontend/bressolium-front/src/routes/AppRoutes.jsx
@@ -1,7 +1,9 @@
-import React, { lazy, Suspense } from 'react';
+import React, { lazy, Suspense, useEffect } from 'react';
 import { Routes, Route, Navigate, Outlet } from 'react-router-dom';
+import { useDispatch } from 'react-redux';
 import ProtectedRoute from './ProtectedRoute';
 import TopBar from '../components/layout/TopBar';
+import { fetchMyGamesThunk } from '../features/game/gameSlice';
 
 const LoginPage      = lazy(() => import('../pages/LoginPage'));
 const RegisterPage   = lazy(() => import('../pages/RegisterPage'));
@@ -30,6 +32,12 @@ function AppRoutes() {
 }
 
 function ProtectedLayout() {
+    const dispatch = useDispatch();
+
+    useEffect(() => {
+        dispatch(fetchMyGamesThunk());
+    }, []);
+
     return (
         <div className="h-screen overflow-hidden flex flex-col bg-[#f7f9f7]">
             <TopBar />

--- a/Bressolium/frontend/bressolium-front/src/services/authService.js
+++ b/Bressolium/frontend/bressolium-front/src/services/authService.js
@@ -34,9 +34,11 @@ const authService = {
     }
 
     // Guardamos el token en localStorage según DoD de Tarea 3
-    localStorage.setItem('auth_token', data.data?.token || data.token);
+    const payload = data.data || data;
+    localStorage.setItem('auth_token', payload.token);
+    if (payload.user) localStorage.setItem('auth_user', JSON.stringify(payload.user));
 
-    return data.data || data;
+    return payload;
   },
 
   /**
@@ -66,9 +68,11 @@ const authService = {
       throw new Error(errorMessage);
     }
 
-    localStorage.setItem('auth_token', data.data?.token || data.token);
+    const payload = data.data || data;
+    localStorage.setItem('auth_token', payload.token);
+    if (payload.user) localStorage.setItem('auth_user', JSON.stringify(payload.user));
 
-    return data.data || data;
+    return payload;
   },
 
   /**
@@ -76,6 +80,8 @@ const authService = {
    */
   logout: () => {
     localStorage.removeItem('auth_token');
+    localStorage.removeItem('auth_user');
+    localStorage.removeItem('current_game');
   },
 
   /**
@@ -83,6 +89,19 @@ const authService = {
    * @returns {string|null}
    */
   getToken: () => localStorage.getItem('auth_token'),
+
+  /**
+   * Recupera los datos del usuario guardados en cliente.
+   * @returns {object|null}
+   */
+  getUser: () => {
+    try {
+      const raw = localStorage.getItem('auth_user');
+      return raw ? JSON.parse(raw) : null;
+    } catch {
+      return null;
+    }
+  },
 };
 
 export default authService;


### PR DESCRIPTION
[BoardService.php] en lugar de cachear un Eloquent Collection (objeto PHP complejo), ahora cachea un array puro. Los arrays siempre serializan/deserializan sin problemas.

- Solo el token se guardaba en localStorage, pero no los datos del usuario (user).

Fix:

[authService.js] al hacer login, guarda también el usuario en localStorage.auth_user
[authSlice.js]( el estado inicial lee el usuario de localStorage: user: authService.getUser()
 

-  myGames vacío	
fix: [AppRoutes.jsx](— ProtectedLayout lanza fetchMyGamesThunk() al montar, re-cargando siempre las partidas del usuario

- currentGame perdido	
fix:  setCurrentGame guarda en localStorage.current_game; el estado inicial lo lee de ahí